### PR TITLE
add expand-file-name when load-file

### DIFF
--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2012-2017  Takeshi Arabiki
 
 ;; Author: Takeshi Arabiki
-;; Version: 0.1.3
+;; Version: 0.1.4
 
 ;;  This program is free software: you can redistribute it and/or modify
 ;;  it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@
   "Run Node.js REPL and communicate the process."
   :group 'processes)
 
-(defconst nodejs-repl-version "0.1.3"
+(defconst nodejs-repl-version "0.1.4"
   "Node.js mode Version.")
 
 (defcustom nodejs-repl-command "node"
@@ -343,7 +343,7 @@ when receive the output string"
 ;;;###autoload
 (defun nodejs-repl-load-file (file)
   "Load the file to the `nodejs-repl-process'"
-  (interactive (list (read-file-name "Load file: " nil nil 'lambda)))
+  (interactive (list (expand-file-name (read-file-name "Load file: " nil nil 'lambda))))
   (let ((proc (nodejs-repl--get-or-create-process)))
     (comint-send-string proc (format ".load %s\n" file))))
 

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2012-2017  Takeshi Arabiki
 
 ;; Author: Takeshi Arabiki
-;; Version: 0.1.4
+;; Version: 0.1.3
 
 ;;  This program is free software: you can redistribute it and/or modify
 ;;  it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@
   "Run Node.js REPL and communicate the process."
   :group 'processes)
 
-(defconst nodejs-repl-version "0.1.4"
+(defconst nodejs-repl-version "0.1.3"
   "Node.js mode Version.")
 
 (defcustom nodejs-repl-command "node"


### PR DESCRIPTION
when `load file`, `.load ~/foo.js` will fail for not recongnizing `~`, so expand filename