### PR TITLE
Use the editor mode of the REPL to send regions.

### DIFF
--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -374,8 +374,13 @@ when receive the output string"
   "Send the current region to the `nodejs-repl-process'"
   (interactive "r")
   (let ((proc (nodejs-repl--get-or-create-process)))
+    ;; Enclose the region in .editor ... EOF as this is more robust.
+    ;; See: https://github.com/abicky/nodejs-repl.el/issues/17
+    (comint-send-string proc ".editor\n")
     (comint-send-region proc start end)
-    (comint-send-string proc "\n")))
+    (comint-send-string proc "\n")
+    (with-current-buffer (process-buffer proc)
+      (comint-send-eof))))
 
 ;;;###autoload
 (defun nodejs-repl-send-buffer ()


### PR DESCRIPTION
This fixes issue #17 (see:
https://github.com/abicky/nodejs-repl.el/issues/17).

* nodejs-repl.el: (nodejs-repl-send-region): Enable the editor mode
when sending the region.