### PR TITLE
Add support for path to Node.js command per project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ You can define key bindings to send JavaScript codes to REPL like below:
                 (define-key js-mode-map (kbd "C-c C-l") 'nodejs-repl-load-file)
                 (define-key js-mode-map (kbd "C-c C-z") 'nodejs-repl-switch-to-repl)))
 
+When a version manager such as nvm is used to run different versions
+of Node.js, it is often desirable to start the REPL of the version
+specified in the .nvmrc file per project.  In such case, customize the
+`nodejs-repl-command` variable with a function symbol.  That function
+should query nvm for the Node.js command to run.  For example:
+
+    (require 'nodejs-repl)
+    (defun nvm-which ()
+      (let* ((shell (concat (getenv "SHELL") " -l -c 'nvm which'"))
+             (output (shell-command-to-string shell)))
+        (cadr (split-string output "[\n]+" t))))
+    (setq nodejs-repl-command #'nvm-which)
+
+The `nvm-which` function can be simpler, and perhaps can run faster,
+too, if using Bash:
+
+    (defun nvm-which ()
+      (let ((output (shell-command-to-string "source ~/.nvm/nvm.sh; nvm which")))
+        (cadr (split-string output "[\n]+" t))))
 
 Author
 ------


### PR DESCRIPTION
If the variable `nodejs-repl-command' is a function symbol, call that function for the path to Node.js command.

This allows to integrate with Node.js version managers such as [nvm](https://github.com/creationix/nvm).

Tested with nvm version 0.33.11 on macOS version 10.13.6, Emacs version 26.1.