### PR TITLE
Support Node.js 12 and stop supporting Node.js 7 or earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
   - 12
@@ -12,17 +11,6 @@ env:
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-26.2-travis
-
-matrix:
-  exclude:
-  - node_js: 6
-    env: EVM_EMACS=emacs-25.1-travis
-  - node_js: 6
-    env: EVM_EMACS=emacs-25.2-travis
-  - node_js: 6
-    env: EVM_EMACS=emacs-25.3-travis
-  - node_js: 6
-    env: EVM_EMACS=emacs-26.1-travis
 
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 6
   - 8
   - 10
+  - 12
 
 env:
   - EVM_EMACS=emacs-24.5-travis
@@ -10,6 +11,7 @@ env:
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
 
 matrix:
   exclude:

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -238,8 +238,8 @@ when receive the output string"
 
 (defun nodejs-repl--get-completions-from-process (token)
   "Get completions sending TAB to Node.js process."
-  (let ((ret (if (version< nodejs-repl-nodejs-version "7.0.0")
-                 (nodejs-repl--send-string (concat token "\t"))
+  (let ((ret (progn
+               ;; Send TAB twice cf. https://github.com/nodejs/node/pull/7754
                (nodejs-repl--send-string (concat token "\t"))
                (nodejs-repl--send-string "\t")))
         completions)

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -532,8 +532,10 @@ otherwise spawn one."
            (nodejs-repl-code (format nodejs-repl-code-format
                                      nodejs-repl-prompt nodejs-repl-use-global repl-mode)))
       (pop-to-buffer
-       (apply 'make-comint nodejs-repl-process-name node-command nil
-              `(,@nodejs-repl-arguments "-e" ,nodejs-repl-code)))
+       ;; Node.js 12 ignores almost all keys if TERM is "dumb"
+       ;; cf. https://github.com/nodejs/node/commit/d3a62fe7fc683bf74b3e9c743f73471f0167bd15
+       (apply 'make-comint nodejs-repl-process-name "env" nil
+              `("TERM=xterm" ,node-command ,@nodejs-repl-arguments "-e" ,nodejs-repl-code)))
       (nodejs-repl-mode))))
 
 (provide 'nodejs-repl)

--- a/test/test.el
+++ b/test/test.el
@@ -27,13 +27,13 @@
        (eq orig-marker (marker-position (process-mark proc)))
        (eq orig-filter (process-filter proc))
        (eq orig-buf (process-buffer proc)))))
-  (expect "100000000"  ; waits for finishing commands
-          (let ((ret (nodejs-repl--send-string "for (i = 0; i < 100000000; i++) {} console.log(i)\n")))
-            (nth 1 (split-string ret "\r\n"))))
-  ;; TODO
-  ;; (expect "100000000"  ; waits for finishing commands
-  ;;   (let ((ret (nodejs-repl-send-string "for (i = 0; i < 20000000; i++) if (!(i % 10000000))process.stdout.write(\"\"+i)\n")))
-  ;;           (nth 1 (split-string ret "\r\n"))))
+  (expect '("100000000" "undefined")  ; waits for finishing commands
+    (let* ((ret (nodejs-repl--send-string "for (i = 0; i < 100000000; i++) {} console.log(i)\n"))
+           (i-value (nth 1 (split-string ret "\r\n")))
+           (return-value (nth 2 (split-string ret "\r\n"))))
+      (list
+       (ansi-color-filter-apply i-value)
+       (ansi-color-filter-apply return-value))))
 
   (desc "nodejs-repl-execute")
   (expect "2\n"

--- a/test/test.el
+++ b/test/test.el
@@ -27,8 +27,8 @@
        (eq orig-marker (marker-position (process-mark proc)))
        (eq orig-filter (process-filter proc))
        (eq orig-buf (process-buffer proc)))))
-  (expect '("100000000" "undefined")  ; waits for finishing commands
-    (let* ((ret (nodejs-repl--send-string "for (i = 0; i < 100000000; i++) {} console.log(i)\n"))
+  (expect '("2" "undefined")  ; waits for finishing commands
+    (let* ((ret (nodejs-repl--send-string "s = Date.now(); while ((d = (Date.now() - s) / 1000 | 0) < 2); console.log(d)\n"))
            (i-value (nth 1 (split-string ret "\r\n")))
            (return-value (nth 2 (split-string ret "\r\n"))))
       (list


### PR DESCRIPTION
This PR resolves #24.
Node.js 12 ignores almost all keys due to the following commit if TERM is "dumb":
https://github.com/nodejs/node/commit/d3a62fe7fc683bf74b3e9c743f73471f0167bd15