### PR TITLE
Support Node.js 13 and stop supporting Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: node_js
 node_js:
   - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 8
   - 10
   - 12
+  - 13
 
 env:
   - EVM_EMACS=emacs-24.5-travis
@@ -11,6 +12,7 @@ env:
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-26.2-travis
+  - EVM_EMACS=emacs-26.3-travis
 
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - 13

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -140,7 +140,7 @@ See also `comint-process-echoes'"
 (defvar nodejs-repl-code-format
   (concat
    "require('repl').start({prompt: '%s', useGlobal: %s, replMode: "
-   "require('repl')['REPL_MODE_' + '%s'.toUpperCase()] })"))
+   "require('repl')['REPL_MODE_' + '%s'.toUpperCase()], preview: false})"))
 
 (defvar nodejs-repl-extra-espace-sequence-re "\\(\x1b\\[[0-9]+[GJK]\\)")
 

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -94,7 +94,7 @@ such as nvm."
   :group 'nodejs-repl
   :type 'string)
 
-(defcustom nodejs-repl-use-global "false"
+(defcustom nodejs-repl-use-global "true"
   "useGlobal option of Node.js REPL method repl.start"
   :group 'nodejs-repl
   :type 'string)

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -530,7 +530,7 @@ otherwise spawn one."
           ;; "v7.3.0" => "7.3.0", "v7.x-dev" => "7"
           (replace-regexp-in-string nodejs-repl--nodejs-version-re "\\1"
                                     (shell-command-to-string (concat node-command " --version"))))
-    (let* ((repl-mode (or (getenv "NODE_REPL_MODE") "magic"))
+    (let* ((repl-mode (or (getenv "NODE_REPL_MODE") "sloppy"))
            (nodejs-repl-code (format nodejs-repl-code-format
                                      nodejs-repl-prompt nodejs-repl-use-global repl-mode)))
       (pop-to-buffer


### PR DESCRIPTION
A preview feature was introduced by https://github.com/BridgeAR/node/commit/6bdf8d106009e4ed0f3c323d0f0874a51acc8e08 in this version and nodejs-repl doesn't work if the feature is enabled.
cf. https://github.com/abicky/nodejs-repl.el/issues/28