### PR TITLE
Stop supporting old Emacs versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         emacs-version:
-          - '24.5'
-          - '25.1'
-          - '25.2'
           - '25.3'
           - '26.1'
           - '26.2'


### PR DESCRIPTION
We stop supporting old Emacs versions for the following reasons:

* Emacs 24.5 was released about 5 years ago, so it is too old.
* There is no reason to use Emacs 25.1 and 25.2 because Emacs 25.2 and 25.3 mainly include bug fixes and security fixes.
