### PR TITLE
Support Node.js 13.7.0

### DIFF
--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -223,7 +223,7 @@ See also `comint-process-echoes'"
              (not
               (let ((last-line (process-get proc 'last-line)))
                 (or (string-match-p nodejs-repl-prompt-re last-line)
-                    (string= last-line string)))))
+                    (string-prefix-p string last-line)))))
     (process-put proc 'running-p nil)
     (accept-process-output proc interval)))
 


### PR DESCRIPTION
This PR fixes infinite loops Node.js 13.7.0 or later causes.
The root cause is the change of the output format on sending the first TAB.

For example, the output on sending a TAB at the end of a line "> Err" changed like below:

* Node.js 13.6.0 or earlier
    ```
    Error^[[1G^[[0J> Error^[[8G
    ```
* Node.js 13.7.0 or later
    ```
    Error
    ```
