### PR TITLE
Added key binding for send-buffer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ You can define key bindings to send JavaScript codes to REPL like below:
             (define-key js-mode-map (kbd "C-x C-e") 'nodejs-repl-send-last-expression)
             (define-key js-mode-map (kbd "C-c C-j") 'nodejs-repl-send-line)
             (define-key js-mode-map (kbd "C-c C-r") 'nodejs-repl-send-region)
+            (define-key js-mode-map (kbd "C-c C-c") 'nodejs-repl-send-buffer)
             (define-key js-mode-map (kbd "C-c C-l") 'nodejs-repl-load-file)
             (define-key js-mode-map (kbd "C-c C-z") 'nodejs-repl-switch-to-repl)))
 ```

--- a/nodejs-repl.el
+++ b/nodejs-repl.el
@@ -43,6 +43,7 @@
 ;;                 (define-key js-mode-map (kbd "C-x C-e") 'nodejs-repl-send-last-expression)
 ;;                 (define-key js-mode-map (kbd "C-c C-j") 'nodejs-repl-send-line)
 ;;                 (define-key js-mode-map (kbd "C-c C-r") 'nodejs-repl-send-region)
+;;                 (define-key js-mode-map (kbd "C-c C-c") 'nodejs-repl-send-buffer)
 ;;                 (define-key js-mode-map (kbd "C-c C-l") 'nodejs-repl-load-file)
 ;;                 (define-key js-mode-map (kbd "C-c C-z") 'nodejs-repl-switch-to-repl)))
 ;;


### PR DESCRIPTION
Same as python shell in emacs, C-c C-c is used to send buffer to repl.